### PR TITLE
Preliminary support for Satisfactory 1.0 plus additions

### DIFF
--- a/SatisfactorySaveNet.Abstracts/ITypedDataSerializer.cs
+++ b/SatisfactorySaveNet.Abstracts/ITypedDataSerializer.cs
@@ -6,5 +6,5 @@ namespace SatisfactorySaveNet.Abstracts;
 
 public interface ITypedDataSerializer
 {
-    public TypedData Deserialize(BinaryReader reader, Header header, string type, bool isArrayProperty);
+    public TypedData Deserialize(BinaryReader reader, Header header, string type, bool isArrayProperty, int binarySize);
 }

--- a/SatisfactorySaveNet.Abstracts/Model/Typed/ClientIdentityInfo.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Typed/ClientIdentityInfo.cs
@@ -1,0 +1,8 @@
+namespace SatisfactorySaveNet.Abstracts.Model.Typed;
+
+public class ClientIdentityInfo : TypedData
+{
+    public override TypedDataConstraint Type => TypedDataConstraint.ClientIdentityInfo;
+
+    public string Value { get; set; } = string.Empty;
+}

--- a/SatisfactorySaveNet.Abstracts/Model/Typed/TypedDataConstraint.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Typed/TypedDataConstraint.cs
@@ -4,6 +4,7 @@ public enum TypedDataConstraint
 {
     ArrayProperties,
     Box,
+    ClientIdentityInfo,
     Color,
     DateTime,
     FactoryCustomizationColorSlot,

--- a/SatisfactorySaveNet.Abstracts/Model/Union/UnionConstraint.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Union/UnionConstraint.cs
@@ -8,6 +8,7 @@ public enum UnionConstraint
     Vector3D,
     Vector3,
     Vector3I,
+    Vector4,
     Int,
     Int64,
     Str,

--- a/SatisfactorySaveNet.Abstracts/Model/Union/Vector4Union.cs
+++ b/SatisfactorySaveNet.Abstracts/Model/Union/Vector4Union.cs
@@ -1,0 +1,9 @@
+using SatisfactorySaveNet.Abstracts.Maths.Vector;
+
+namespace SatisfactorySaveNet.Abstracts.Model.Union;
+
+public class Vector4Union : UnionBase
+{
+    public override UnionConstraint Type => UnionConstraint.Vector4;
+    public Vector4 Value { get; set; }
+}

--- a/SatisfactorySaveNet/PropertySerializer.cs
+++ b/SatisfactorySaveNet/PropertySerializer.cs
@@ -441,7 +441,7 @@ public class PropertySerializer : IPropertySerializer
 
         for (var x = 0; x < length; x++)
         {
-            values[x] = _typedDataSerializer.Deserialize(reader, header, elementType, true);
+            values[x] = _typedDataSerializer.Deserialize(reader, header, elementType, true, binarySize);
         }
 
         var property = new ArrayStructProperty
@@ -829,6 +829,11 @@ public class PropertySerializer : IPropertySerializer
                         value = new Vector3Union { Value = _vectorSerializer.DeserializeVec3(reader) };
                         break;
                     }
+                    if (propertyName.Equals("mDestroyedPickups", StringComparison.Ordinal))
+                    {
+                        value = new Vector4Union { Value = _vectorSerializer.DeserializeVec4(reader) };
+                        break;
+                    }
                     value = new FINNetworkUnion { Value = DeserializeFINNetworkProperty(reader) };
                     break;
                 case nameof(NameProperty):
@@ -890,7 +895,7 @@ public class PropertySerializer : IPropertySerializer
         var padding1 = reader.ReadInt64();
         var padding2 = reader.ReadInt64();
         var padding3 = reader.ReadSByte();
-        var typedData = _typedDataSerializer.Deserialize(reader, header, type, false);
+        var typedData = _typedDataSerializer.Deserialize(reader, header, type, false, binarySize);
 
         var property = new StructProperty
         {

--- a/SatisfactorySaveNet/TypedDataSerializer.cs
+++ b/SatisfactorySaveNet/TypedDataSerializer.cs
@@ -39,7 +39,7 @@ public class TypedDataSerializer : ITypedDataSerializer
         _objectReferenceSerializer = objectReferenceSerializer;
     }
 
-    public TypedData Deserialize(BinaryReader reader, Header header, string type, bool isArrayProperty)
+    public TypedData Deserialize(BinaryReader reader, Header header, string type, bool isArrayProperty, int binarySize)
     {
         return type switch
         {
@@ -63,6 +63,7 @@ public class TypedDataSerializer : ITypedDataSerializer
             nameof(FICFrameRange) => DeserializeFICFrameRange(reader),
             nameof(IntPoint) => DeserializeIntPoint(reader),
             nameof(FINGPUT1BufferPixel) => DeserializeFINGPUT1BufferPixel(reader),
+            nameof(ClientIdentityInfo) => DeserializeClientIdentityInfo(reader, binarySize),
             //ToDo: All implemented?
 
             //nameof(InventoryStack) => DeserializeInventoryStack(reader, header),
@@ -107,6 +108,21 @@ public class TypedDataSerializer : ITypedDataSerializer
             Character = character,
             ForegroundColor = foregroundColor,
             BackgroundColor = backgroundColor
+        };
+    }
+
+    private ClientIdentityInfo DeserializeClientIdentityInfo(BinaryReader reader, int binarySize)
+    {
+        var value = _stringSerializer.Deserialize(reader);
+
+        if (binarySize - 4 - value.Length > 0)
+        {
+            _ = reader.ReadBytes(binarySize - 4 - value.Length - 1);
+        }
+
+        return new ClientIdentityInfo
+        {
+            Value = value
         };
     }
 
@@ -434,7 +450,9 @@ public class TypedDataSerializer : ITypedDataSerializer
         "/Game/FactoryGame/Resource/Equipment/JetPack/BP_EquipmentDescriptorJetPack.BP_EquipmentDescriptorJetPack_C",
         "/Game/FactoryGame/Resource/Equipment/NailGun/Desc_RebarGunProjectile.Desc_RebarGunProjectile_C",
         "/Game/FactoryGame/Resource/Equipment/Rifle/BP_EquipmentDescriptorRifle.BP_EquipmentDescriptorRifle_C",
-        "/Game/FactoryGame/Resource/Equipment/NobeliskDetonator/BP_EquipmentDescriptorNobeliskDetonator.BP_EquipmentDescriptorNobeliskDetonator_C"
+        "/Game/FactoryGame/Resource/Equipment/NobeliskDetonator/BP_EquipmentDescriptorNobeliskDetonator.BP_EquipmentDescriptorNobeliskDetonator_C",
+        "/Game/FactoryGame/Resource/Equipment/GemstoneScanner/BP_EquipmentDescriptorObjectScanner.BP_EquipmentDescriptorObjectScanner_C",
+        "/Game/FactoryGame/Resource/Equipment/GasMask/BP_EquipmentDescriptorGasmask.BP_EquipmentDescriptorGasmask_C"
     }.ToFrozenSet(StringComparer.Ordinal);
 
     private InventoryItem DeserializeInventoryItem(BinaryReader reader, Header header, bool isArrayProperty)


### PR DESCRIPTION
I'm not entirely sure if these changes all pertain to the recent game release, but they are needed nonetheless to load my savegame (currently in T8, approaching T9).
If you want to separate these changes into their own PRs, feel free to do so 😉 

**Original commit message:**
A new variant of TypedData called `ClientIdentifyInfo` needs to be processed. It contains a hex string as an ID, along with some additional but currently unknown bytes.

The property `mDestroyedPickups` also requires processing. It is currently treated as a collection of Vector4s, though this may or may not be accurate and requires further clarification.

The list of items with state (i.e., `FueledInventoryItem`) has been updated to include the object scanner and the gas mask. It may be worth considering renaming the subclass, e.g., to `StatefulInventoryItem`.